### PR TITLE
Issue-#96: Enable opentest4j when junit 4 seems not to be present.

### DIFF
--- a/src/main/java/com/github/dakusui/pcond/validator/Validator.java
+++ b/src/main/java/com/github/dakusui/pcond/validator/Validator.java
@@ -629,6 +629,8 @@ public interface Validator {
       }
 
       public Configuration build() {
+        if (!isClassPresent("org.junit.ComparisonFailure"))
+          this.useOpentest4J();
         return new Configuration() {
           private final Debugging debugging = new Debugging() {
           };
@@ -684,6 +686,15 @@ public interface Validator {
             return Builder.this.clone();
           }
         };
+      }
+
+      private static boolean isClassPresent(String s) {
+        try {
+          Class.forName(s);
+          return true;
+        } catch (ClassNotFoundException e) {
+          return false;
+        }
       }
 
       @Override


### PR DESCRIPTION
Issue-#96: Enable opentest4j when junit 4 seems not to be present.
Check it by the presence of `org.junit.ComparisonFailure'.
